### PR TITLE
current datasource context access in before and after method hooks

### DIFF
--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -346,6 +346,7 @@ export class GSFunction extends Function {
         }
 
         if (ds.before_method_hook) {
+          ctx.config['context'] = args;
           await ds.before_method_hook(ctx);
         }
       }
@@ -406,6 +407,7 @@ export class GSFunction extends Function {
 
     if (args.datasource?.after_method_hook) {
       ctx.outputs['current_output'] = status;
+      ctx.config['context'] = args;
       await args.datasource.after_method_hook(ctx);
     }
     return status;


### PR DESCRIPTION
Devs will be able to access the context of the datasource in before and after method hooks workflow using **<% config.context %>**

example: [ 1 ] ### context of datasource **type: api**

```
{
  "type": "api",
  "base_url": "https://dummyjson.com",
  "gsName": "testdatasource",
  "url": "/products/1",
  "method": "post",
  "body": {
    "test": "key"
  }
}
```

example: [ 2 ] ### context of datasource **type: kafka**

```
{
    "datasource": {
      "type": "kafka",
      "client_id": "CRM_Integration_Service",
      "brokers": ["kafka:9094"],
      "client": {
        "config": {
          "type": "kafka",
          "client_id": "CRM_Integration_Service",
          "brokers": ["kafka:9094"],
          "before_method_hook": "com.jfs.audit_log_workflow",
          "after_method_hook": "com.jfs.after_log_workflow"
        },
        "kafka": {},
        "consumers": {},
        "subscribers": {},
        "_producer": {
          "events": {
            "CONNECT": "producer.connect",
            "DISCONNECT": "producer.disconnect",
            "REQUEST": "producer.network.request",
            "REQUEST_TIMEOUT": "producer.network.request_timeout",
            "REQUEST_QUEUE_SIZE": "producer.network.request_queue_size"
          }
        }
      },
      "gsName": "kafka_test"
    },
    "config": {
      "method": "publish",
      "topic": "test-topic"
    },
    "data": {
      "value": {
        "Gender": "Male"
      }
    }
  }
```