### PR TITLE
Masking (enabled) Bug on updating multiple record & listing records

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -329,7 +329,7 @@ async function main() {
     childLogger = logger.child(childLogAttributes);
 
     childLogger.info('Processing event %s', event.type);
-    childLogger.info('event inputs %o', event.data);
+    childLogger.info('event inputs %o', _.cloneDeep(event.data));
     childLogger.debug('event spec: %o', events[event.type]);
     const responseStructure: GSResponse = {
       apiVersion: (config as any).api_version || '1.0',
@@ -486,9 +486,9 @@ async function main() {
     }
 
     if (code < 400) {
-      childLogger.info('return value %o %o %o', data, code, headers);
+      childLogger.info('return value %o %o %o', _.cloneDeep(data), code, headers);
     } else {
-      childLogger.error('return value %o %o %o', data, code, headers);
+      childLogger.error('return value %o %o %o', _.cloneDeep(data), code, headers);
     }
 
     (event.metadata?.http?.express.res as express.Response)

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -304,7 +304,7 @@ export class GSFunction extends Function {
     let args = this.args;
 
     try {
-      childLogger.info({ 'workflow_name': this.workflow_name,'task_id': this.id }, 'Executing handler %s %o', this.id, this.args);
+      childLogger.info({ 'workflow_name': this.workflow_name,'task_id': this.id }, 'Executing handler %s %o', this.id, _.cloneDeep(this.args));
       if (Array.isArray(this.args)) {
         args = [...this.args];
       } else if (_.isPlainObject(this.args)) {
@@ -368,7 +368,7 @@ export class GSFunction extends Function {
         res = await this.fn!(args, {childLogger, promClient, tracer});
       }
 
-      childLogger.info({ 'workflow_name': this.workflow_name,'task_id': this.id }, `Result of _executeFn ${this.id} %o`, res);
+      childLogger.info({ 'workflow_name': this.workflow_name,'task_id': this.id }, `Result of _executeFn ${this.id} %o`, _.cloneDeep(res));
 
       if (res instanceof GSStatus) {
         status = res;
@@ -407,7 +407,9 @@ export class GSFunction extends Function {
 
     if (args.datasource?.after_method_hook) {
       ctx.outputs['current_output'] = status;
-      ctx.config['context'] = args;
+      if(!ctx.config.context){
+        ctx.config['context'] = args;
+      }
       await args.datasource.after_method_hook(ctx);
     }
     return status;
@@ -484,7 +486,7 @@ export class GSFunction extends Function {
     let caching: PlainObject | null = null;
     let redisClient;
     try {
-        childLogger.info({ 'workflow_name': this.workflow_name,'task_id': this.id }, '_call invoked with task value %s %o', this.id, taskValue);
+        childLogger.info({ 'workflow_name': this.workflow_name,'task_id': this.id }, '_call invoked with task value %s %o', this.id, _.cloneDeep(taskValue));
         let prismaArgs;
     
         childLogger.setBindings({ 'workflow_name': this.workflow_name,'task_id': this.id});
@@ -533,11 +535,11 @@ export class GSFunction extends Function {
             throw ctx.exitWithStatus;
           }
         }
-        childLogger.info({ 'workflow_name': this.workflow_name,'task_id': this.id }, 'args after evaluation: %s %o', this.id, args);
+        childLogger.info({ 'workflow_name': this.workflow_name,'task_id': this.id }, 'args after evaluation: %s %o', this.id, _.cloneDeep(args));
     
         if (prismaArgs) {
           args.data = _.merge(args.data, prismaArgs);
-          childLogger.info({ 'workflow_name': this.workflow_name,'task_id': this.id }, 'merged args with authz args.data: %o', args);
+          childLogger.info({ 'workflow_name': this.workflow_name,'task_id': this.id }, 'merged args with authz args.data: %o', _.cloneDeep(args));
         }
     
         childLogger.setBindings({ 'workflow_name': '','task_id': ''});


### PR DESCRIPTION
cloned data for loggers which doesn't override the values processed by  the redact plugin

This PR resolves masking enabled issue that causes last entry to show in all the records of the response.