### PR TITLE
invalid payload fix and error message instead of error stack in response

### DIFF
--- a/src/functions/com/gs/datastore.ts
+++ b/src/functions/com/gs/datastore.ts
@@ -67,7 +67,7 @@ export default async function(args:{[key:string]:any;}) {
     status_message = err.message || 'Error in getting prisma method from client!';
     datastoreSpan.setStatus({ code: SpanStatusCode.ERROR, message: status_message});
     cleanupTraces(attributes);
-    return new GSStatus(false, attributes.status_code, status_message, JSON.stringify(err.stack));
+    return new GSStatus(false, attributes.status_code, status_message, JSON.stringify(err.message));
   }
 
   try {
@@ -79,9 +79,10 @@ export default async function(args:{[key:string]:any;}) {
     //TODO: better check for error codes. Return 500 for server side error. 40X for client errors.
     attributes.status_code = 400;
     status_message = err.message || 'Error in query!';
+    childLogger.error(`${status_message} %o`, err.stack);
     datastoreSpan.setStatus({ code: SpanStatusCode.ERROR, message: status_message});
     cleanupTraces(attributes);
-    return new GSStatus(false, attributes.status_code, status_message, JSON.stringify(err.stack));
+    return new GSStatus(false, attributes.status_code, status_message, JSON.stringify(err.message));
   }
 
 }

--- a/src/http_listener.ts
+++ b/src/http_listener.ts
@@ -35,6 +35,15 @@ const file_size_limit = config.file_size_limit || 50 * 1024 * 1024;
 
 app.use(bodyParser.urlencoded({ extended: true, limit: request_body_limit }));
 app.use(bodyParser.json({ limit: request_body_limit }));
+app.use((req,res,next) => {
+  bodyParser.json({ limit: request_body_limit })(req,res,err =>{
+    if (err) {
+      logger.error('Bad request: %o', err.stack);
+      return res.status(400).send(err.message); // Bad request
+    } 
+    next();
+  });
+});
 app.use(loggerExpress);
 
 try {


### PR DESCRIPTION
Issue is whenever request payload JSON structure is invalid, Godspeed service return very descriptive error exposing internal code class/package names.

For example: Any Invalid JSON structure.

Response from Godspeed service:

 

```
<!DOCTYPE html>
<html lang="en">
<head>

                  <meta charset="utf-8">

                  <title>Error</title>

</head>
<body>

                  <pre>SyntaxError: Unexpected token &#39; in JSON at position 7<br> &nbsp; &nbsp;at JSON.parse (&lt;anonymous&gt;)<br> &nbsp; &nbsp;at parse (/workspace/development/gs_service/node_modules/body-parser/lib/types/json.js:89:19)<br> &nbsp; &nbsp;at /workspace/development/gs_service/node_modules/body-parser/lib/read.js:128:18<br> &nbsp; &nbsp;at AsyncResource.runInAsyncScope (node:async_hooks:202:9)<br> &nbsp; &nbsp;at invokeCallback (/workspace/development/gs_service/node_modules/raw-body/index.js:231:16)<br> &nbsp; &nbsp;at done (/workspace/development/gs_service/node_modules/raw-body/index.js:220:7)<br> &nbsp; &nbsp;at IncomingMessage.onEnd (/workspace/development/gs_service/node_modules/raw-body/index.js:280:7)<br> &nbsp; &nbsp;at [/workspace/development/gs_service/node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/context-async-hooks/build/src/AbstractAsyncHooksContextManager.js:49:55<br](mailto:/workspace/development/gs_service/node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/context-async-hooks/build/src/AbstractAsyncHooksContextManager.js:49:55%3cbr)> &nbsp; &nbsp;at AsyncLocalStorage.run (node:async_hooks:327:14)<br> &nbsp; &nbsp;at AsyncLocalStorageContextManager.with ([/workspace/development/gs_service/node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/context-async-hooks/build/src/AsyncLocalStorageContextManager.js:33:40)<br](mailto:/workspace/development/gs_service/node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/context-async-hooks/build/src/AsyncLocalStorageContextManager.js:33:40)%3cbr)> &nbsp; &nbsp;at IncomingMessage.contextWrapper ([/workspace/development/gs_service/node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/context-async-hooks/build/src/AbstractAsyncHooksContextManager.js:49:32)<br](mailto:/workspace/development/gs_service/node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/context-async-hooks/build/src/AbstractAsyncHooksContextManager.js:49:32)%3cbr)> &nbsp; &nbsp;at IncomingMessage.emit (node:events:539:35)<br> &nbsp; &nbsp;at endReadableNT (node:internal/streams/readable:1345:12)<br> &nbsp; &nbsp;at processTicksAndRejections (node:internal/process/task_queues:83:21)</pre>
</body>
</html>
```


Fixed

on invalid payload it returns
status: 400 
data: Unexpected token e in JSON at position 4

