### PR TITLE
added auto generated swagger documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "prom-client": "^12.0.0",
         "socket.io": "^4.7.2",
         "sonic-boom": "^3.2.0",
-        "swagger-ui-express": "^4.4.0",
+        "swagger-ui-express": "^4.6.3",
         "yaml": "^2.0.0"
       },
       "devDependencies": {
@@ -60,6 +60,7 @@
         "@types/node-cron": "^3.0.7",
         "@types/passport": "^1.0.8",
         "@types/passport-jwt": "^3.0.6",
+        "@types/swagger-ui-express": "^4.1.4",
         "@typescript-eslint/eslint-plugin": "^5.23.0",
         "@typescript-eslint/parser": "^5.23.0",
         "chai": "^4.3.6",
@@ -2119,6 +2120,16 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.3.tgz",
       "integrity": "sha512-F/IjUGnV6pIN7R4ZV4npHJVoNtaLZWvb+2/9gctxjb99wkpI7Ozg8VPogwDiTRyjLwZXAYxjvdg1KS8LTHKdDA=="
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.4.tgz",
+      "integrity": "sha512-h6dfIPFveCJKpStDtjrB+4pig4DAf9Uu2Z51RB7Fj3s6AifexmqhZxBoG50K/k3Afz7wyXsIAY5ZIDTlC2VjrQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.25.0",
@@ -7212,9 +7223,9 @@
       "integrity": "sha512-B0Iy2ueXtbByE6OOyHTi3lFQkpPi/L7kFOKFeKTr44za7dJIELa9kzaca6GkndCgpK1QTjArnoXG+aUy0XQp1w=="
     },
     "node_modules/swagger-ui-express": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.4.0.tgz",
-      "integrity": "sha512-1CzRkHG386VQMVZK406jcpgnW2a9A5A/NiAjKhsFTQqUBWRF+uGbXTU/mA7WSV3mTzyOQDvjBdWP/c2qd5lqKw==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.3.tgz",
+      "integrity": "sha512-CDje4PndhTD2HkgyKH3pab+LKspDeB/NhPN2OF1j+piYIamQqBYwAXWESOT1Yju2xFg51bRW9sUng2WxDjzArw==",
       "dependencies": {
         "swagger-ui-dist": ">=4.11.0"
       },
@@ -7222,7 +7233,7 @@
         "node": ">= v0.10.32"
       },
       "peerDependencies": {
-        "express": ">=4.0.0"
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/table": {
@@ -9243,6 +9254,16 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.3.tgz",
       "integrity": "sha512-F/IjUGnV6pIN7R4ZV4npHJVoNtaLZWvb+2/9gctxjb99wkpI7Ozg8VPogwDiTRyjLwZXAYxjvdg1KS8LTHKdDA=="
+    },
+    "@types/swagger-ui-express": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.4.tgz",
+      "integrity": "sha512-h6dfIPFveCJKpStDtjrB+4pig4DAf9Uu2Z51RB7Fj3s6AifexmqhZxBoG50K/k3Afz7wyXsIAY5ZIDTlC2VjrQ==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.25.0",
@@ -12917,9 +12938,9 @@
       "integrity": "sha512-B0Iy2ueXtbByE6OOyHTi3lFQkpPi/L7kFOKFeKTr44za7dJIELa9kzaca6GkndCgpK1QTjArnoXG+aUy0XQp1w=="
     },
     "swagger-ui-express": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.4.0.tgz",
-      "integrity": "sha512-1CzRkHG386VQMVZK406jcpgnW2a9A5A/NiAjKhsFTQqUBWRF+uGbXTU/mA7WSV3mTzyOQDvjBdWP/c2qd5lqKw==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.3.tgz",
+      "integrity": "sha512-CDje4PndhTD2HkgyKH3pab+LKspDeB/NhPN2OF1j+piYIamQqBYwAXWESOT1Yju2xFg51bRW9sUng2WxDjzArw==",
       "requires": {
         "swagger-ui-dist": ">=4.11.0"
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "prom-client": "^12.0.0",
     "socket.io": "^4.7.2",
     "sonic-boom": "^3.2.0",
-    "swagger-ui-express": "^4.4.0",
+    "swagger-ui-express": "^4.6.3",
     "yaml": "^2.0.0"
   },
   "devDependencies": {
@@ -67,6 +67,7 @@
     "@types/node-cron": "^3.0.7",
     "@types/passport": "^1.0.8",
     "@types/passport-jwt": "^3.0.6",
+    "@types/swagger-ui-express": "^4.1.4",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.23.0",
     "chai": "^4.3.6",

--- a/src/router/swagger.ts
+++ b/src/router/swagger.ts
@@ -1,58 +1,29 @@
-import config from 'config';
 import { PlainObject } from "../types";
 
-const port = process.env.PORT || 3000;
-const customServerUrl = (config as any).server_url || `http://localhost:${port}`;
+export const generateSwaggerJSON = (events: PlainObject, definitions: PlainObject, eventSourceConfig: PlainObject) => {
 
+  const finalSpecs: { [key: string]: any } = { openapi: "3.0.0", paths: {} };
 
-const swaggerCommonPart = {
-  "openapi": "3.0.0",
-  "info": {
-    "version": "0.0.1",
-    "title": "Godspeed: Sample Microservice",
-    "description": "Sample API calls demonstrating the functionality of Godspeed framework",
-    "termsOfService": "http://swagger.io/terms/",
-    "contact": {
-      "name": "Mindgrep Technologies Pvt Ltd",
-      "email": "talktous@mindgrep.com",
-      "url": "https://docs.mindgrep.com/docs/microservices/intro"
-    },
-    "license": {
-      "name": "Apache 2.0",
-      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
-    }
-  },
-  "servers": [{
-    "url": "http://localhost:3001"
-  }],
-  "paths": {}
-};
-
-
-export const generateSwaggerJSON = (events: PlainObject, definitions: PlainObject) => {
-
-  const finalSpecs = JSON.parse(JSON.stringify(swaggerCommonPart)); // deep clone
+  const { port, docs: { info } } = eventSourceConfig;
 
   Object.keys(events).forEach(event => {
-    let apiEndPoint = event.split('.')[0];
+    let apiEndPoint = event.split('.')[2];
     apiEndPoint = apiEndPoint.replace(/:([^\/]+)/g, '{$1}'); //We take :path_param. OAS3 takes {path_param}
-    const method = event.split('.')[2];
+    const method = event.split('.')[1];
     const eventSchema = events[event];
 
     //Initialize the schema for this method, for given event
     let methodSpec: PlainObject = {
       summary: eventSchema.summary,
       description: eventSchema.description,
-      requestBody: eventSchema.body || eventSchema.data?.schema?.body,
-      parameters:
-        eventSchema.parameters ||
-        eventSchema.params ||
-        eventSchema.data?.schema?.params,
+      requestBody: eventSchema.body,
+      parameters: eventSchema.params,
       responses: eventSchema.responses,
     };
 
     //Set it in the overall schema
     // @ts-ignore
+
     finalSpecs.paths[apiEndPoint] = {
       // @ts-ignore
       ...finalSpecs.paths[apiEndPoint],
@@ -60,6 +31,10 @@ export const generateSwaggerJSON = (events: PlainObject, definitions: PlainObjec
     };
   });
 
+  finalSpecs.servers = [{
+    "url": `http://localhost:${port}`
+  }];
+  finalSpecs.info = info;
   finalSpecs.definitions = definitions;
 
   return finalSpecs;


### PR DESCRIPTION
There are few assumptions while enabling this feature.

1. SwaggerUI only works only for express type of http event source. So once we are introducing new http event sources, We might need to look into in again.
2. Swagger Docs are only for http events, So I guess the best place for this is express plugin. But currently we are sending each event one by one. So the code for this is in core as of now.

@gurjotkaur20 Can you review this PR.

Tomorrow I will add the documentation for this, and the default config in `express` plugin.