### PR TITLE
adding capability to access datasource in event source plugins

### DIFF
--- a/src/core/_interfaces/sources.ts
+++ b/src/core/_interfaces/sources.ts
@@ -46,9 +46,12 @@ export abstract class GSEventSource {
 
   client: false | PlainObject;
 
-  constructor(config: PlainObject) {
+  datasources: PlainObject;
+
+  constructor(config: PlainObject, datasources: PlainObject) {
     this.config = config;
     this.client = false;
+    this.datasources = datasources;
   };
 
   public async init() {

--- a/src/core/eventsourceLoader.ts
+++ b/src/core/eventsourceLoader.ts
@@ -24,7 +24,7 @@ export default async function (eventsourcesFolderPath: string, datasources: Plai
       let Constructor = Module.default;
 
       if (isPureEventSource) {
-        eventSourceInatance = new Constructor(eventsourcesConfigs[esName]) as GSEventSource;
+        eventSourceInatance = new Constructor(eventsourcesConfigs[esName], datasources) as GSEventSource;
         if ('init' in eventSourceInatance) {
           await eventSourceInatance.init();
         }


### PR DESCRIPTION
This PR will allow pure event source plugins to access datasource client and config.

So to access a datasource in `initClient` or `subscribeToEvent` of of a pure event source. Here is a short example.

```js
class EventSource extends GSEventSource {
  initClient() {
    const redisClient = this.datasources['redis'].client;
  }

  subscribeToEvents() {
    const redisClient = this.datasources['redis'].client;
  }
}
```

PS: Symbolic code, only for demonstration.