### PR TITLE
modified http-event-source client to fastify

### DIFF
--- a/src/godspeed.ts
+++ b/src/godspeed.ts
@@ -302,14 +302,20 @@ class Godspeed {
     const httpEventSource = this.eventsources['http']; // eslint-disable-line
     if (httpEventSource?.config?.docs) {
       const _httpEvents = generateSwaggerJSON(httpEvents, this.definitions, httpEventSource.config);
-      // @ts-ignore
-      httpEventSource.client.use(httpEventSource.config.docs.endpoint || '/api-docs', swaggerUI.serve, swaggerUI.setup(_httpEvents));
+      //@ts-ignore
+      if(httpEventSource.client.express){
+        // @ts-ignore
+          httpEventSource.client.express.use(httpEventSource.config.docs.endpoint || '/api-docs', swaggerUI.serve, swaggerUI.setup(_httpEvents));
+      }else{
+        // @ts-ignore
+          httpEventSource.client.use(httpEventSource.config.docs.endpoint || '/api-docs', swaggerUI.serve, swaggerUI.setup(_httpEvents));
+      }
     }
 
     if (process.env.OTEL_ENABLED == 'true') {
-      // @ts-ignore
-      httpEventSource.client.get('/metrics', async (req, res) => {
-        let prismaMetrics: string = '';
+      //@ts-ignore
+      const handleMetrics = async (req, res) => {
+      let prismaMetrics = '';
         for (let ds in this.datasources) {
           // @ts-ignore
           if (this.datasources[ds].config.type === 'prisma') {
@@ -322,7 +328,15 @@ class Godspeed {
         let appMetrics = await promClient.register.metrics();
 
         res.end(appMetrics + prismaMetrics);
-      });
+      };
+      //@ts-ignore
+      if (httpEventSource.client.express) {
+        //@ts-ignore
+        httpEventSource.client.express.get('/metrics', handleMetrics);
+      } else {
+        // @ts-ignore
+        httpEventSource.client.get('/metrics', handleMetrics);
+      }
     }
   }
 


### PR DESCRIPTION
Modified httpEventsource client access to Fastify because to use express as a middleware to the fastify. Description to this PR is mentioned in this [Issue](https://github.com/godspeedsystems/gs-node-service/issues/812).