### PR TITLE
fix: config/custom-environment-variables issue fixed

### DIFF
--- a/src/godspeed.ts
+++ b/src/godspeed.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/first */
-require('dotenv').config();
+import 'dotenv/config';
 
 try {
   if (process.env.OTEL_ENABLED == 'true') {


### PR DESCRIPTION
Fixes #905 

### Description
Updated dotenv require statement to import statement so that swc compiler doesn't put it after the other import statements. dotenv should be imported at the very beginning so that config module can use env variables defined in .env file.