### PR TITLE
fix: extract prisma client metrics only if previewFeatures has metrics

### DIFF
--- a/src/godspeed.ts
+++ b/src/godspeed.ts
@@ -311,8 +311,7 @@ class Godspeed {
       httpEventSource.client.get('/metrics', async (req, res) => {
         let prismaMetrics: string = '';
         for (let ds in this.datasources) {
-          // @ts-ignore
-          if (this.datasources[ds].config.type === 'prisma') {
+          if (this.datasources[ds].client?._previewFeatures.includes("metrics")) {
             // @ts-ignore
             prismaMetrics += await this.datasources[ds].client.$metrics.prometheus({
               globalLabels: { server: process.env.HOSTNAME, datasource: `${ds}` },


### PR DESCRIPTION
Fixes #922 