### PR TITLE
Fix com gs return

### DIFF
--- a/src/functions/com/gs/return.ts
+++ b/src/functions/com/gs/return.ts
@@ -17,7 +17,7 @@ export default function (ctx: GSContext, args: PlainObject) {
     success = success !== undefined && success !== null ? success : false;
     code = code || (!success && 403) || 200;
   } else {
-    success = v1Compatible ? true : success;
+    success = v1Compatible ? true : (success !== undefined && success !== null ? success : true);
     code = v1Compatible ? 200 : code || 200;
   }
 

--- a/src/functions/com/gs/return.ts
+++ b/src/functions/com/gs/return.ts
@@ -1,4 +1,4 @@
-import { GSContext, logger } from "../../../godspeed";
+import { GSContext } from "../../../godspeed";
 import { PlainObject } from "../../../types";
 
 /*
@@ -6,7 +6,6 @@ import { PlainObject } from "../../../types";
 * © 2022 Mindgrep Technologies Pvt Ltd
 */
 export default function (ctx: GSContext, args: PlainObject) {
-  logger.info("*** args: %o", args);
   let success = args.success;
   let code = args.code;
   const v1Compatible = args.returnV1Compatible;

--- a/src/functions/com/gs/return.ts
+++ b/src/functions/com/gs/return.ts
@@ -1,5 +1,4 @@
-import { P } from "pino";
-import { GSContext, GSStatus } from "../../../godspeed";
+import { GSContext } from "../../../godspeed";
 import { PlainObject } from "../../../types";
 
 /*
@@ -13,12 +12,12 @@ export default function (ctx: GSContext, args: PlainObject) {
   delete args.code;
 
   if (ctx.forAuth) {
-    success = success || false;
+    success = success !== undefined && success !== null ? success : false;;
     code = code || (!success && 403) || 200;
   } else {
-    success = true;
+    success = success !== undefined && success !== null ? success : true;
     code = code || 200;
   }
-  
+
   return {success: success, code: code, data: args, exitWithStatus: true };
 }

--- a/src/functions/com/gs/return.ts
+++ b/src/functions/com/gs/return.ts
@@ -1,4 +1,4 @@
-import { GSContext } from "../../../godspeed";
+import { GSContext, logger } from "../../../godspeed";
 import { PlainObject } from "../../../types";
 
 /*
@@ -6,18 +6,21 @@ import { PlainObject } from "../../../types";
 * © 2022 Mindgrep Technologies Pvt Ltd
 */
 export default function (ctx: GSContext, args: PlainObject) {
+  logger.info("*** args: %o", args);
   let success = args.success;
   let code = args.code;
+  const v1Compatible = args.returnV1Compatible;
   delete args.success;
   delete args.code;
+  delete args.returnV1Compatible;
 
   if (ctx.forAuth) {
-    success = success !== undefined && success !== null ? success : false;;
+    success = success !== undefined && success !== null ? success : false;
     code = code || (!success && 403) || 200;
   } else {
-    success = success !== undefined && success !== null ? success : true;
-    code = code || 200;
+    success = v1Compatible ? true : success;
+    code = v1Compatible ? 200 : code || 200;
   }
 
-  return {success: success, code: code, data: args, exitWithStatus: true };
+  return {success: success, code: code, data: v1Compatible ? args : args.data, exitWithStatus: true };
 }


### PR DESCRIPTION
- Added `returnV1Compatible` flag, which, if set to true, will make com.gs.return method behave like v1 functionality: 
```
success: true
code: 200
data: <the complete args object>
```
- If this flag is not present, i.e. v2 then the function expects a GSStatus type object.
```
success: <args.success>
code: <args.code>
data: <args.data>
```